### PR TITLE
Add the deprecated function

### DIFF
--- a/configure.md
+++ b/configure.md
@@ -175,7 +175,11 @@ For Graylog, it's recommended to create an index set. To do so, navigate to Syst
 
 ![Graylog Index Set](https://www.bsmithio.com/post/opnsense-dashboard/indexset.png)
 
-Once that's done, download the [content pack](https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/config/OPNsense-pack.json) and install it on Graylog by navigating to System -> Content Packs -> Upload, choose the pack, Upload, then Install.
+Once that's done, download the [content pack](https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/config/OPNsense-pack.json) and install it on Graylog by navigating to System -> Content Packs -> Upload, choose the pack, Upload
+
+Go back to the content packs and install the one you just uploaded
+
+> Note: make sure you actually install the pack you just uploaded
 
 Now, add your index set from earlier to the "OPNsense / filterlog" stream. Navigate to Streams -> More Actions -> Edit Stream -> select your index set and save.
 

--- a/configure.md
+++ b/configure.md
@@ -41,7 +41,7 @@ You will need to have Docker and Docker Compose installed on a server that will 
 
 After you've installed Docker and Docker Compose, download the docker-compose.yaml from this repo.
 
-`curl https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/docker-compose.yaml -o docker-compose.yaml`
+`curl https://raw.githubusercontent.com/MansoorMajeed/OPNsense-Dashboard/master/docker-compose.yaml -o docker-compose.yaml`
 
 It's important that you change the TZ environment variable to your timezone for everything to work properly.
 I also recommend you change the passwords in this compose file as well.

--- a/configure.md
+++ b/configure.md
@@ -120,18 +120,18 @@ Add the  [custom.conf](./config/custom.conf) telegraf config to /usr/local/etc/t
 sudo mkdir /usr/local/etc/telegraf.d
 sudo chown telegraf:telegraf /usr/local/etc/telegraf.d
 sudo chmod 750 /usr/local/etc/telegraf.d
-sudo curl https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/config/custom.conf -o /usr/local/etc/telegraf.d/custom.conf
+sudo curl https://raw.githubusercontent.com//MansoorMajeed/OPNsense-Dashboard/master/config/custom.conf -o /usr/local/etc/telegraf.d/custom.conf
 ```
 
 ### Telegraf Plugins
 
 **Plugins must be copied to your OPNsense system**
 
-Place [telegraf_pfifgw.php](https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/plugins/telegraf_pfifgw.php) and [telegraf_temperature.sh](https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/plugins/telegraf_temperature.sh) in /usr/local/bin and chmod them to 755.
+Place [telegraf_pfifgw.php](https://raw.githubusercontent.com//MansoorMajeed/OPNsense-Dashboard/master/plugins/telegraf_pfifgw.php) and [telegraf_temperature.sh](https://raw.githubusercontent.com//MansoorMajeed/OPNsense-Dashboard/master/plugins/telegraf_temperature.sh) in /usr/local/bin and chmod them to 755.
 
 ```
-curl "https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/plugins/telegraf_pfifgw.php" -o /usr/local/bin/telegraf_pfifgw.php
-curl "https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/plugins/telegraf_temperature.sh" -o /usr/local/bin/telegraf_temperature.sh
+curl "https://raw.githubusercontent.com//MansoorMajeed/OPNsense-Dashboard/master/plugins/telegraf_pfifgw.php" -o /usr/local/bin/telegraf_pfifgw.php
+curl "https://raw.githubusercontent.com//MansoorMajeed/OPNsense-Dashboard/master/plugins/telegraf_temperature.sh" -o /usr/local/bin/telegraf_temperature.sh
 chmod 755 /usr/local/bin/telegraf_temperature.sh /usr/local/bin/telegraf_pfifgw.php
 ```
 
@@ -288,7 +288,7 @@ Restart telegraf by running
 
 ### Import the Suricata Dashboard
 
-To import the dashboard, copy the JSON from [OPNsense-Grafana-Dashboard-Suricata.json](https://raw.githubusercontent.com/bsmithio/OPNsense-Dashboard/master/OPNsense-Grafana-Dashboard-Suricata.json) and navigate to Dashboards -> Browse -> Import and paste under Import via panel json.
+To import the dashboard, copy the JSON from [OPNsense-Grafana-Dashboard-Suricata.json](https://raw.githubusercontent.com//MansoorMajeed/OPNsense-Dashboard/master/OPNsense-Grafana-Dashboard-Suricata.json) and navigate to Dashboards -> Browse -> Import and paste under Import via panel json.
 
 ## Troubleshooting
 

--- a/plugins/telegraf_pfifgw.php
+++ b/plugins/telegraf_pfifgw.php
@@ -5,6 +5,225 @@ require_once("interfaces.inc");
 require_once("plugins.inc.d/dpinger.inc");
 require_once("util.inc");
 
+
+
+
+# Added function get_interface_info. Function was removed from interface.in in OPNsense version 24.1
+function get_interfaces_info($include_unlinked = false)
+{
+    global $config;
+
+    $all_intf_details = legacy_interfaces_details();
+    $all_intf_stats = legacy_interface_stats();
+    $gateways = new \OPNsense\Routing\Gateways();
+    $ifup = legacy_interface_listget('up');
+    $result = [];
+    $interfaces = legacy_config_get_interfaces(['virtual' => false]);
+    $known_interfaces = [];
+    foreach (array_keys($interfaces) as $ifdescr) {
+        $interfaces[$ifdescr]['if'] = get_real_interface($ifdescr);
+        if (!empty($interfaces[$ifdescr]['if'])) {
+            $known_interfaces[] = $interfaces[$ifdescr]['if'];
+        }
+        $interfaces[$ifdescr]['ifv6'] = get_real_interface($ifdescr, 'inet6');
+        if (!empty($interfaces[$ifdescr]['ifv6'])) {
+            $known_interfaces[] = $interfaces[$ifdescr]['ifv6'];
+        }
+    }
+
+    if ($include_unlinked) {
+        $unassigned_descr = gettext("Unassigned");
+        foreach ($all_intf_details as $if => $ifdata) {
+            if (!in_array($if, $known_interfaces)) {
+                $interfaces[$if] = ["descr" => $unassigned_descr, "if" => $if, "ifv6" => $if, 'unassigned' => true];
+            }
+        }
+    }
+
+    foreach ($interfaces as $ifdescr => $ifinfo) {
+        $ifinfo['status'] = in_array($ifinfo['if'], $ifup) ? 'up' : 'down';
+        $ifinfo['statusv6'] = in_array($ifinfo['ifv6'], $ifup) ? 'up' : 'down';
+
+        /* undesired side effect of legacy_config_get_interfaces() */
+        $ifinfo['ipaddr'] = $ifinfo['ipaddrv6'] = null;
+
+        if (!empty($all_intf_details[$ifinfo['if']])) {
+            if (
+                isset($all_intf_details[$ifinfo['if']]['status']) &&
+                    in_array($all_intf_details[$ifinfo['if']]['status'], array('active', 'running'))
+            ) {
+                $all_intf_details[$ifinfo['if']]['status'] = $ifinfo['status'];
+            }
+            $ifinfo = array_merge($ifinfo, $all_intf_details[$ifinfo['if']]);
+        }
+
+        if (!empty($ifinfo['ipv4'])) {
+            list ($primary4,, $bits4) = interfaces_primary_address($ifdescr, $all_intf_details);
+            if (!empty($primary4)) {
+                $ifinfo['ipaddr'] = $primary4;
+                $ifinfo['subnet'] = $bits4;
+            } else {
+                $ifinfo['ipaddr'] = $ifinfo['ipv4'][0]['ipaddr'];
+                $ifinfo['subnet'] = $ifinfo['ipv4'][0]['subnetbits'];
+            }
+        }
+
+        if (!empty($all_intf_details[$ifinfo['ifv6']]['ipv6'])) {
+            /* rewrite always as it can be a different interface */
+            $ifinfo['ipv6'] = $all_intf_details[$ifinfo['ifv6']]['ipv6'];
+        } elseif ($ifinfo['if'] != !$ifinfo['ifv6']) {
+            /* clear on a mismatch to avoid wrong data here */
+            $ifinfo['ipv6'] = [];
+        }
+
+        if (!empty($ifinfo['ipv6'])) {
+            list ($primary6,, $bits6) = interfaces_primary_address6($ifdescr, $all_intf_details);
+            if (!empty($primary6)) {
+                $ifinfo['ipaddrv6'] = $primary6;
+                $ifinfo['subnetv6'] = $bits6;
+            }
+            foreach ($ifinfo['ipv6'] as $ipv6addr) {
+                if (!empty($ipv6addr['link-local'])) {
+                    $ifinfo['linklocal'] = $ipv6addr['ipaddr'];
+                } elseif (empty($ifinfo['ipaddrv6'])) {
+                    $ifinfo['ipaddrv6'] = $ipv6addr['ipaddr'];
+                    $ifinfo['subnetv6'] = $ipv6addr['subnetbits'];
+                }
+            }
+
+            $aux = shell_safe('/usr/local/sbin/ifctl -6pi %s', $ifinfo['ifv6']);
+            if (!empty($aux)) {
+                $ifinfo['prefixv6'] = explode("\n", $aux);
+            }
+        }
+
+        $ifinfotmp = $all_intf_stats[$ifinfo['if']];
+        $ifinfo['inbytes'] = $ifinfotmp['bytes received'];
+        $ifinfo['outbytes'] = $ifinfotmp['bytes transmitted'];
+        $ifinfo['inpkts'] = $ifinfotmp['packets received'];
+        $ifinfo['outpkts'] = $ifinfotmp['packets transmitted'];
+        $ifinfo['inerrs'] = $ifinfotmp['input errors'];
+        $ifinfo['outerrs'] = $ifinfotmp['output errors'];
+        $ifinfo['collisions'] = $ifinfotmp['collisions'];
+
+        $link_type = $config['interfaces'][$ifdescr]['ipaddr'] ?? 'none';
+        switch ($link_type) {
+            case 'dhcp':
+                $ifinfo['dhcplink'] = isvalidpid("/var/run/dhclient.{$ifinfo['if']}.pid") ? 'up' : 'down';
+                break;
+            /* PPPoE/PPTP/L2TP interface? -> get status from virtual interface */
+            case 'pppoe':
+            case 'pptp':
+            case 'l2tp':
+                if ($ifinfo['status'] == "up") {
+                    /* XXX get PPPoE link status for dial on demand */
+                    $ifinfo["{$link_type}link"] = "up";
+                } else {
+                    $ifinfo["{$link_type}link"] = "down";
+                }
+                break;
+            /* PPP interface? -> get uptime for this session and cumulative uptime from the persistent log file in conf */
+            case 'ppp':
+                if ($ifinfo['status'] == "up") {
+                    $ifinfo['ppplink'] = "up";
+                } else {
+                    $ifinfo['ppplink'] = "down";
+                }
+
+                if (empty($ifinfo['status'])) {
+                    $ifinfo['status'] = "down";
+                }
+
+                if (isset($config['ppps']['ppp'])) {
+                    foreach ($config['ppps']['ppp'] as $pppid => $ppp) {
+                        if ($config['interfaces'][$ifdescr]['if'] == $ppp['if']) {
+                            break;
+                        }
+                    }
+                }
+                if ($config['interfaces'][$ifdescr]['if'] != $ppp['if'] || empty($ppp['ports'])) {
+                    break;
+                }
+                if (!file_exists($ppp['ports'])) {
+                    $ifinfo['nodevice'] = 1;
+                    $ifinfo['pppinfo'] = $ppp['ports'] . " " . gettext("device not present! Is the modem attached to the system?");
+                }
+
+                // Calculate cumulative uptime for PPP link. Useful for connections that have per minute/hour contracts so you don't go over!
+                if (isset($ppp['uptime'])) {
+                    $ifinfo['ppp_uptime_accumulated'] = "(" . get_ppp_uptime($ifinfo['if']) . ")";
+                }
+                break;
+            default:
+                break;
+        }
+
+        if (file_exists("/var/run/{$link_type}_{$ifdescr}.pid")) {
+            $sec = intval(shell_safe('/usr/local/opnsense/scripts/interfaces/ppp-uptime.sh %s', $ifinfo['if']));
+            if ($sec) {
+                $ifinfo['ppp_uptime'] = convert_seconds_to_hms($sec);
+            }
+        }
+
+        switch ($config['interfaces'][$ifdescr]['ipaddrv6'] ?? 'none') {
+            case 'dhcp6':
+                $ifinfo['dhcp6link'] = isvalidpid('/var/run/dhcp6c.pid') && file_exists("/var/etc/dhcp6c_{$ifdescr}.conf") ? 'up' : 'down';
+                break;
+            /* XXX more to do here in the future */
+            default:
+                break;
+        }
+
+        if ($ifinfo['status'] == "up") {
+            $wifconfiginfo = array();
+            if (isset($config['interfaces'][$ifdescr]['wireless'])) {
+                exec("/sbin/ifconfig {$ifinfo['if']} list sta", $wifconfiginfo);
+                array_shift($wifconfiginfo);
+            }
+            foreach ($wifconfiginfo as $ici) {
+                $elements = preg_split("/[ ]+/i", $ici);
+                if ($elements[0] != "") {
+                    $ifinfo['bssid'] = $elements[0];
+                }
+                if ($elements[3] != "") {
+                    $ifinfo['rate'] = $elements[3];
+                }
+                if ($elements[4] != "") {
+                    $ifinfo['rssi'] = $elements[4];
+                }
+            }
+            $gateway = $gateways->getInterfaceGateway($ifdescr, 'inet');
+            if (!empty($gateway)) {
+                $ifinfo['gateway'] = $gateway;
+            }
+            $gatewayv6 = $gateways->getInterfaceGateway($ifdescr, 'inet6');
+            if (!empty($gatewayv6)) {
+                $ifinfo['gatewayv6'] = $gatewayv6;
+            }
+        }
+
+        $bridge = link_interface_to_bridge($ifdescr);
+        if ($bridge) {
+            $bridge_text = shell_safe('/sbin/ifconfig %s', $bridge);
+            if (stristr($bridge_text, 'blocking') != false) {
+                $ifinfo['bridge'] = "<b><span class='text-danger'>" . gettext("blocking") . "</span></b> - " . gettext("check for ethernet loops");
+                $ifinfo['bridgeint'] = $bridge;
+            } elseif (stristr($bridge_text, 'learning') != false) {
+                $ifinfo['bridge'] = gettext("learning");
+                $ifinfo['bridgeint'] = $bridge;
+            } elseif (stristr($bridge_text, 'forwarding') != false) {
+                $ifinfo['bridge'] = gettext("forwarding");
+                $ifinfo['bridgeint'] = $bridge;
+            }
+        }
+
+        $result[$ifdescr] = $ifinfo;
+    }
+
+    return $result;
+}
+
+
 $host = gethostname();
 $source = "pfconfig";
 


### PR DESCRIPTION
`get_interfaces_info` was deprecated, this PR adds it to the plugin so the plugin does not have to be rewritten.
I copied the function from https://github.com/opnsense/core/blob/e0e1401f8739e3359a9d968d435e3a42ccff3d37/src/etc/inc/interfaces.inc#L3909